### PR TITLE
Build against Ubuntu 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
             artifact: win32-x64,
           }
         - {
-            name: "Ubuntu_Latest_GCC",
+            name: "Ubuntu_22_GCC",
             os: ubuntu-22.04,
             artifact: linux-x64,
           }


### PR DESCRIPTION
Fixes: #6

Build against Ubuntu 22 instead of 24 (see [here](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#choosing-github-hosted-runners) for details).