### PR TITLE
Add linux-arm64 to the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: 
+        config:
         - {
             name: "Windows Latest MSVC",
             os: windows-latest,
@@ -29,6 +29,11 @@ jobs:
             name: "Ubuntu_22_GCC",
             os: ubuntu-22.04,
             artifact: linux-x64,
+          }
+        - {
+            name: "Ubuntu_24_ARM64",
+            os: ubuntu-24.04-arm,
+            artifact: linux-arm64,
           }
         - {
             name: "macOS Latest Clang",
@@ -90,7 +95,7 @@ jobs:
         run: |
           brew install cmake
           cmake --version
-          
+
       - name: Build
         shell: bash
         run: |

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -13,7 +13,7 @@ npm version patch # or minor or major
 git push --tag upstream main
 ```
 
-That should build all 3 platforms and then publish a new package
+That should build all 4 platforms and then publish a new package
 on npm. At the time of this writing that generally takes 20-30 minutes.
 
 ## Notes


### PR DESCRIPTION
Add `linux-arm64` to the CI build matrix using `ubuntu-24.04-arm` runner.                                                                                                  

Produces `linux-arm64.dawn.node` alongside existing win32-x64, linux-x64, and darwin-universal binaries. Uses Ubuntu 24.04 because 22.04's GCC 11 + binutils 2.38 on aarch64 hits `R_AARCH64_ADR_PREL_PG_HI21` relocation overflows when linking `dawn.node`. GCC 14 in 24.04 handles this correctly.
